### PR TITLE
Update embed-fonts.js

### DIFF
--- a/tasks/embed-fonts.js
+++ b/tasks/embed-fonts.js
@@ -22,8 +22,8 @@ module.exports = function (grunt) {
 
   function getDataUri(fontFile) {
     var typeMatch = fontType.exec(fontFile),
-        faceContent = grunt.file.read(fontFile),
-        fontEncoded = new Buffer(faceContent).toString('base64');
+        faceContent = grunt.file.read(fontFile, {encoding: null}),
+        fontEncoded = faceContent.toString('base64');
     return 'data:font/' + typeMatch[1] + ';base64,' + fontEncoded;
   }
 


### PR DESCRIPTION
By default grunt.file.read use utf-8 encoding, but font files are binary. So you shouldnt encode binary files to utf-8
